### PR TITLE
lich.rbw - updated version number for minor edit

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -37,7 +37,7 @@
 #
 
 # Based on Lich 4.6.49
-LICH_VERSION = '4.12.0f'
+LICH_VERSION = '4.12.1f'
 TESTING = false
 KEEP_SAFE = RUBY_VERSION =~ /^2\.[012]\./
 


### PR DESCRIPTION
Updated version number to 4.12.1f for the minor edit