### PR TITLE
Add tag to rooms to disable fuzzy room logic

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -37,7 +37,7 @@
 #
 
 # Based on Lich 4.6.49
-LICH_VERSION = '4.12.1f'
+LICH_VERSION = '4.13.1f'
 TESTING = false
 KEEP_SAFE = RUBY_VERSION =~ /^2\.[012]\./
 


### PR DESCRIPTION
Allows rooms that have nearly identical room descriptions to only be matched if its completely identical.

Would allow us to map crafting rooms that are all nearly the same save for a different color door, etc.