### PR TITLE
Build script.vars when Script arg input is an Array

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -2883,7 +2883,8 @@ class Script
             @vars.concat args[:args].scan(/[^\s"]*(?<!\\)"(?:\\"|[^"])+(?<!\\)"[^\s]*|(?:\\"|[^"\s])+/).collect { |s| s.gsub(/(?<!\\)"/,'').gsub('\\"', '"') }
          end
       elsif args[:args].class == Array
-         @vars = args[:args] # fixme: set @vars[0] ?
+         @vars = [ args[:args].join(" ") ]
+         @vars.concat args[:args]
       else
          @vars = Array.new
       end


### PR DESCRIPTION
Fixes #46

script.vars wasn't being built correctly when the args input to the Script object was an Array.

The behavior should conform to http://lichproject.sourceforge.net/api.xml

```
variable
(script.vars)
>> an array, possibly empty
variable[1]
It's an array containing the command line variables the user entered when starting the script (begins at variable[1], unlike standard arrays; as is the behavior of Wizard, variable[0] is the entire line the user entered).```