### PR TITLE
export WINEPREFIX when using --wine-prefix

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -12077,7 +12077,7 @@ main_thread = Thread.new {
                end
             elsif defined?(Wine)
                Lich.log "info: launcher_cmd: #{Wine::BIN} #{launcher_cmd}"
-               spawn "#{Wine::BIN} #{launcher_cmd}"
+               spawn({"WINEPREFIX"=>"#{Wine::PREFIX}"}, "#{Wine::BIN} #{launcher_cmd}")
             else
                Lich.log "info: launcher_cmd: #{launcher_cmd}"
                spawn launcher_cmd


### PR DESCRIPTION
wine requires WINEPREFIX exported in order for it to use said prefix. If you don't explicitly export it prior to starting lich, the wrong prefix is used when using --wine-prefix, resulting in failure to find the simu launcher exe.